### PR TITLE
feat: allow server to handle multiple calls

### DIFF
--- a/match.go
+++ b/match.go
@@ -1,0 +1,116 @@
+package servermock
+
+import (
+	"errors"
+	"net/http"
+)
+
+var (
+	ErrNoNextResponseFound = errors.New("it was not possible to found a next response")
+)
+
+// A Match is used to connect a Request to one or multiple possible Response(s) so that when the request happens the mock server
+// returns the desired response.
+type Match interface {
+	// Request returns the request that triggers the match
+	Request() Request
+	// Next response returns the next response associated with the match and records which request triggered the match.
+	// If the list of responses is exhausted it will return a ErrNoNextResponseFound error
+	NextResponse(req *http.Request) (Response, error)
+	// NumberOfCalls returns the number of times the match was fulfilled
+	NumberOfCalls() int
+	// Matches returns the list of http.Request that matched with this Match
+	Matches() []*http.Request
+}
+
+// A FixedResponseMatch is a match that returns a fixed Response each time a predefined Request happens
+type FixedResponseMatch struct {
+	request       Request
+	response      Response
+	numberOfCalls int
+	matches       []*http.Request
+}
+
+// NewFixedResponseMatch creates a new FixedResponseMatch
+func NewFixedResponseMatch(request Request, response Response) *FixedResponseMatch {
+	return &FixedResponseMatch{
+		request:       request,
+		response:      response,
+		numberOfCalls: 0,
+		matches:       make([]*http.Request, 0),
+	}
+}
+
+// Request returns the request that triggers the match
+func (m *FixedResponseMatch) Request() Request {
+	return m.request
+}
+
+// Next response returns the next response associated with the match and records which request triggered the match.
+// It never raises an error
+func (m *FixedResponseMatch) NextResponse(req *http.Request) (Response, error) {
+	m.matches = append(m.matches, cloneHttpRequest(req))
+
+	return m.response, nil
+}
+
+// Matches returns the list of http.Request that matched with this Match
+func (m *FixedResponseMatch) Matches() []*http.Request {
+	return m.matches
+}
+
+// NumberOfCalls returns the number of times the match was fulfilled
+func (m *FixedResponseMatch) NumberOfCalls() int {
+	return len(m.matches)
+}
+
+// A FixedResponseMatch is a match that returns a different Response each time a predefined Request happens
+//
+// Important: the list of responses gets consumed by the server. Do not reuse this structure, create a new one
+type MultipleResponsesMatch struct {
+	request       Request
+	responses     Responses
+	numberOfCalls int
+	matches       []*http.Request
+}
+
+// NewFixedResponseMatch creates a new FixedResponseMatch
+func NewMultipleResponsesMatch(request Request, responses Responses) *MultipleResponsesMatch {
+	return &MultipleResponsesMatch{
+		request:       request,
+		responses:     responses,
+		numberOfCalls: 0,
+		matches:       make([]*http.Request, 0),
+	}
+}
+
+// Request returns the request that triggers the match
+func (m *MultipleResponsesMatch) Request() Request {
+	return m.request
+}
+
+// Next response returns the next response associated with the match.
+// If the list of responses is exhausted it will return a ErrNoNextResponseFound error
+// It consumes the list associated with the MultipleResponsesMatch
+func (m *MultipleResponsesMatch) NextResponse(req *http.Request) (Response, error) {
+	if len(m.responses) == 0 {
+		return Response{}, ErrNoNextResponseFound
+	}
+
+	m.matches = append(m.matches, cloneHttpRequest(req))
+
+	head, tail := m.responses[0], m.responses[1:]
+	m.responses = tail
+
+	return head, nil
+}
+
+// Matches returns the list of http.Request that matched with this Match
+func (m *MultipleResponsesMatch) Matches() []*http.Request {
+	return m.matches
+}
+
+// NumberOfCalls returns the number of times the match was fulfilled
+func (m *MultipleResponsesMatch) NumberOfCalls() int {
+	return len(m.matches)
+}

--- a/match_test.go
+++ b/match_test.go
@@ -1,0 +1,76 @@
+package servermock_test
+
+import (
+	"net/http"
+
+	"github.com/dfioravanti/servermock"
+)
+
+func (s *TestSuite) TestFixedResponseMatchHasExpectedResponse() {
+	request := servermock.NewRequest(
+		servermock.WithRequestURL("/"),
+		servermock.WithRequestMethod(http.MethodPost),
+	)
+	response := servermock.NoContentResponse
+
+	match := servermock.NewFixedResponseMatch(request, response)
+
+	s.Equal(request, match.Request())
+}
+
+func (s *TestSuite) TestFixedResponseRespondsForever() {
+	request := servermock.NewRequest(
+		servermock.WithRequestURL("/"),
+		servermock.WithRequestMethod(http.MethodPost),
+	)
+	expectedResponse := servermock.NoContentResponse
+
+	match := servermock.NewFixedResponseMatch(request, expectedResponse)
+	expectedNumberOfCalls := 1000
+
+	for range expectedNumberOfCalls {
+		response, err := match.NextResponse(&http.Request{})
+
+		s.NoError(err)
+		s.Equal(request, match.Request())
+		s.Equal(expectedResponse, response)
+	}
+
+	s.Equal(expectedNumberOfCalls, match.NumberOfCalls())
+}
+
+func (s *TestSuite) TestMultipleResponsesHasExpectedResponse() {
+	request := servermock.NewRequest(
+		servermock.WithRequestURL("/"),
+		servermock.WithRequestMethod(http.MethodPost),
+	)
+	responses := servermock.Responses{servermock.NoContentResponse}
+
+	match := servermock.NewMultipleResponsesMatch(request, responses)
+
+	s.Equal(request, match.Request())
+}
+
+func (s *TestSuite) TestMultipleResponsesRespondsTheCorrectNumberOfTimes() {
+	request := servermock.NewRequest(
+		servermock.WithRequestURL("/"),
+		servermock.WithRequestMethod(http.MethodPost),
+	)
+
+	expectedFirstResponse := servermock.CreatedResponse
+	expectedSecondResponse := servermock.NoContentResponse
+	responses := servermock.Responses{expectedFirstResponse, expectedSecondResponse}
+
+	match := servermock.NewMultipleResponsesMatch(request, responses)
+
+	firstResponse, err := match.NextResponse(&http.Request{})
+	s.NoError(err)
+	s.Equal(expectedFirstResponse, firstResponse)
+
+	secondResponse, err := match.NextResponse(&http.Request{})
+	s.NoError(err)
+	s.Equal(expectedSecondResponse, secondResponse)
+
+	_, err = match.NextResponse(&http.Request{})
+	s.ErrorIs(err, servermock.ErrNoNextResponseFound)
+}

--- a/misses.go
+++ b/misses.go
@@ -1,0 +1,19 @@
+package servermock
+
+import "fmt"
+
+type whyMissed string
+
+const (
+	pathDoesNotMatch   = whyMissed("The path does not match")
+	methodDoesNotMatch = whyMissed("The method does not match")
+)
+
+type Miss struct {
+	MissedMatch Request
+	Why         whyMissed
+}
+
+func (m Miss) String() string {
+	return fmt.Sprintf("%v missed %v", m.MissedMatch, m.Why)
+}

--- a/request.go
+++ b/request.go
@@ -2,30 +2,33 @@ package servermock
 
 import (
 	"encoding/json"
-	"fmt"
+	"reflect"
 	"regexp"
 )
 
 type Request struct {
-	URL        string            `json:"url"`
+	Url        string            `json:"url"`
 	Method     string            `json:"method"`
 	Headers    map[string]string `json:"headers"`
-	Body       string
-	responses  []Response
 	urlAsRegex regexp.Regexp
+}
+
+// Equal checks if a request is identical to another
+func (r Request) Equal(r2 Request) bool {
+	return reflect.DeepEqual(r, r2)
 }
 
 func (r Request) String() string {
 	bytes, err := json.Marshal(r)
 	if err != nil {
-		panic(fmt.Sprintf("cannot marshal request"))
+		panic("cannot marshal request")
 	}
 	return string(bytes)
 }
 
 func WithRequestURL(url string) func(*Request) {
 	return func(r *Request) {
-		r.URL = url
+		r.Url = url
 		r.urlAsRegex = *regexp.MustCompile(url)
 	}
 }
@@ -51,7 +54,9 @@ func WithRequestHeader(header string, value string) func(*Request) {
 }
 
 func NewRequest(options ...func(*Request)) Request {
-	r := Request{}
+	r := Request{
+		Headers: make(map[string]string),
+	}
 	for _, o := range options {
 		o(&r)
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,17 @@
+package servermock_test
+
+import (
+	"net/http"
+
+	"github.com/dfioravanti/servermock"
+)
+
+func (s *TestSuite) TestEqualityWorks() {
+	r := servermock.NewRequest(
+		servermock.WithRequestURL("/test"),
+		servermock.WithRequestMethod(http.MethodPatch),
+		servermock.WithRequestHeader("foo", "bar"),
+	)
+
+	s.True(r.Equal(r))
+}

--- a/response.go
+++ b/response.go
@@ -1,17 +1,66 @@
 package servermock
 
-import "net/http"
-
 type Response struct {
 	body    []byte
 	status  int
 	headers map[string]string
 }
 
-var Response200 = Response{status: http.StatusOK}
+type Responses = []Response
+
+// The list of all status codes is available at
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+
+// Information responses
+var (
+	ContinueResponse           = NewResponse(WithResponseStatus(100))
+	SwitchingProtocolsResponse = NewResponse(WithResponseStatus(101))
+	ProcessingResponse         = NewResponse(WithResponseStatus(102))
+	EarlyHintsResponse         = NewResponse(WithResponseStatus(103))
+)
+
+// Successful responses
+var (
+	OkResponse                          = NewResponse(WithResponseStatus(200))
+	CreatedResponse                     = NewResponse(WithResponseStatus(201))
+	AcceptedResponse                    = NewResponse(WithResponseStatus(202))
+	NonAuthoritativeInformationResponse = NewResponse(WithResponseStatus(203))
+	NoContentResponse                   = NewResponse(WithResponseStatus(204))
+	ResetContentResponse                = NewResponse(WithResponseStatus(205))
+	PartialContentResponse              = NewResponse(WithResponseStatus(206))
+)
+
+// Redirection messages
+var (
+	MultipleChoicesResponse = NewResponse(WithResponseStatus(300))
+)
+
+// Client error responses
+var (
+	BadRequestsResponse      = NewResponse(WithResponseStatus(400))
+	UnauthorizedResponse     = NewResponse(WithResponseStatus(401))
+	PaymentRequiredResponse  = NewResponse(WithResponseStatus(402))
+	ForbiddenResponse        = NewResponse(WithResponseStatus(403))
+	NotFoundResponse         = NewResponse(WithResponseStatus(404))
+	MethodNotAllowedResponse = NewResponse(WithResponseStatus(405))
+	NotAcceptableResponse    = NewResponse(WithResponseStatus(406))
+)
+
+// Server error responses
+var (
+	InternalServerErrorResponse = NewResponse(WithResponseStatus(500))
+)
 
 func WithResponseBody(body []byte) func(*Response) {
 	return func(r *Response) {
+		r.body = body
+	}
+}
+
+func WithResponseJSONBody(body []byte) func(*Response) {
+	return func(r *Response) {
+		r.headers["Content-Type"] = "application/json"
+
 		r.body = body
 	}
 }
@@ -37,7 +86,9 @@ func WithResponseHeader(header string, value string) func(*Response) {
 }
 
 func NewResponse(options ...func(*Response)) Response {
-	r := Response{}
+	r := Response{
+		headers: make(map[string]string),
+	}
 	for _, o := range options {
 		o(&r)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1,16 +1,15 @@
-package servermock
+package servermock_test
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/dfioravanti/servermock"
 )
 
-func TestMockMatchesOnRoute(t *testing.T) {
-	t.Parallel()
-
+func (s *TestSuite) TestMockMatchesOnRoute() {
 	testCases := []struct {
 		matchPath  string
 		calledPath string
@@ -23,31 +22,25 @@ func TestMockMatchesOnRoute(t *testing.T) {
 		name := fmt.Sprintf("match %s with %s", tc.matchPath, tc.calledPath)
 		client := http.Client{}
 
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+		s.Run(name, func() {
+			registry := servermock.NewRegistry()
+			registry.AddSimpleRequest(http.MethodGet, tc.matchPath)
 
-			mock := NewMock()
-			mock.AddRequest(NewRequest(
-				WithRequestURL(tc.matchPath),
-				WithRequestMethod(http.MethodGet),
-			))
-
-			server := mock.GetServer()
+			server := registry.GetServer(s.T())
 			defer server.Close()
 
 			request, err := http.NewRequest(http.MethodGet, server.URL+tc.calledPath, nil)
-			assert.NoError(t, err)
+			s.NoError(err)
 
 			res, err := client.Do(request)
-			assert.NoError(t, err)
+			s.NoError(err)
 
-			assert.Equal(t, http.StatusOK, res.StatusCode)
+			s.Equal(http.StatusOK, res.StatusCode)
 		})
 	}
 }
 
-func TestMockMatchesOnMethod(t *testing.T) {
-	t.Parallel()
+func (s *TestSuite) TestMockMatchesOnMethod() {
 
 	testCases := []struct {
 		method string
@@ -67,25 +60,103 @@ func TestMockMatchesOnMethod(t *testing.T) {
 		path := "/test"
 		client := http.Client{}
 
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+		s.Run(name, func() {
 
-			mock := NewMock()
-			mock.AddRequest(NewRequest(
-				WithRequestURL(path),
-				WithRequestMethod(tc.method),
-			))
+			registry := servermock.NewRegistry()
+			registry.AddSimpleRequest(tc.method, path)
 
-			server := mock.GetServer()
+			server := registry.GetServer(s.T())
 			defer server.Close()
 
 			request, err := http.NewRequest(tc.method, server.URL+path, nil)
-			assert.NoError(t, err)
+			s.NoError(err)
 
 			res, err := client.Do(request)
-			assert.NoError(t, err)
+			s.NoError(err)
 
-			assert.Equal(t, http.StatusOK, res.StatusCode)
+			s.Equal(http.StatusOK, res.StatusCode)
 		})
 	}
+}
+
+func (s *TestSuite) TestAccessTheRequestBodyWorks() {
+
+	path := "/users"
+
+	expectedBody := []byte(`
+	{
+		user_id: 10,
+		foo: "bar",
+		logged_in: true
+	}
+	`)
+
+	registry := servermock.NewRegistry()
+	mockRequest := servermock.NewRequest(
+		servermock.WithRequestMethod(http.MethodPost),
+		servermock.WithRequestURL(path),
+	)
+	registry.AddRequest(mockRequest)
+
+	server := registry.GetServer(s.T())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewBuffer(expectedBody))
+	s.NoError(err)
+
+	client := http.Client{}
+	res, err := client.Do(req)
+	s.NoError(err)
+
+	s.Equal(http.StatusOK, res.StatusCode)
+
+	matchingRequests := registry.GetMatchesPerRequest(mockRequest)
+	s.Equal(1, len(matchingRequests))
+
+	bodyBytes, err := io.ReadAll(matchingRequests[0].Body)
+	s.NoError(err)
+
+	s.Equal(expectedBody, bodyBytes)
+}
+
+func (s *TestSuite) TestMockResponseWithBody() {
+
+	path := "/users"
+
+	expectedBody := []byte(`
+	{
+		user_id: 10,
+		foo: "bar",
+		logged_in: true
+	}
+	`)
+
+	mock := servermock.NewRegistry()
+	mock.AddRequestWithResponse(
+		servermock.NewRequest(
+			servermock.WithRequestMethod(http.MethodPost),
+			servermock.WithRequestURL(path),
+		),
+		servermock.NewResponse(
+			servermock.WithResponseStatus(http.StatusCreated),
+			servermock.WithResponseJSONBody(expectedBody),
+		),
+	)
+
+	server := mock.GetServer(s.T())
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodPost, server.URL+path, nil)
+	s.NoError(err)
+
+	client := http.Client{}
+	res, err := client.Do(request)
+	s.NoError(err)
+
+	s.Equal(http.StatusCreated, res.StatusCode)
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	s.NoError(err)
+
+	s.Equal(expectedBody, bodyBytes)
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,15 @@
+package servermock_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSuite struct {
+	suite.Suite
+}
+
+func TestRunSuite(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,24 @@
+package servermock
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// cloneHttpRequest clones a http.Request in full
+// By default the .clone does not clone the body
+func cloneHttpRequest(req *http.Request) *http.Request {
+	buf, err := io.ReadAll(req.Body)
+	if err != nil {
+		panic(fmt.Sprintf("cannot read body of request with error: %v", err))
+	}
+
+	newRequest := req.Clone(req.Context())
+
+	req.Body = io.NopCloser(bytes.NewBuffer(buf))
+	newRequest.Body = io.NopCloser(bytes.NewBuffer(buf))
+
+	return newRequest
+}


### PR DESCRIPTION
- Created fixed and variable response matches. Fix matches always return the same when called, variable matches allow to specify a list of calls and the list is exausted when used.
- Added helper methods to make request registration easier
- Added equality between requests
- Added tests