### PR TITLE
feat: allow partial matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ func TestHttpRegistryWorks(t *testing.T) {
 	defer registry.CheckAllResponsesAreConsumed()
 
     // 2. Add request to the registry
-	registry.AddSimpleRequest(http.MethodGet, "/users")
+	registry.AddMethodAndURL(http.MethodGet, "/users")
 
     // 3. Create the server
 	server := registry.GetServer()
@@ -84,10 +84,10 @@ func TestMultipleMatchingWorks(t *testing.T) {
 	defer registry.CheckAllResponsesAreConsumed()
 
 	// 2. Add requests to the registry
-	registry.AddSimpleRequestWithStatusCode(
+	registry.AddMethodAndURLWithStatusCode(
         http.MethodGet, "/users", http.StatusOK,
     )
-	registry.AddSimpleRequestWithStatusCode(
+	registry.AddMethodAndURLWithStatusCode(
         http.MethodGet, "/users", http.StatusNotFound,
     )
 

--- a/docs_test.go
+++ b/docs_test.go
@@ -18,7 +18,7 @@ func TestHttpRegistryWorks(t *testing.T) {
 	defer registry.CheckAllResponsesAreConsumed()
 
 	// 2. Add request to the registry
-	registry.AddSimpleRequest(http.MethodGet, "/users")
+	registry.AddMethodAndURL(http.MethodGet, "/users")
 
 	// 3. Create the server
 	server := registry.GetServer()
@@ -42,8 +42,8 @@ func TestMultipleMatchingWorks(t *testing.T) {
 	defer registry.CheckAllResponsesAreConsumed()
 
 	// 2. Add requests to the registry
-	registry.AddSimpleRequestWithStatusCode(http.MethodGet, "/users", http.StatusOK)
-	registry.AddSimpleRequestWithStatusCode(http.MethodGet, "/users", http.StatusNotFound)
+	registry.AddMethodAndURLWithStatusCode(http.MethodGet, "/users", http.StatusOK)
+	registry.AddMethodAndURLWithStatusCode(http.MethodGet, "/users", http.StatusNotFound)
 
 	// 3. Create the server
 	server := registry.GetServer()

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/dfioravanti/httpregistry
 
-go 1.22.7
+go 1.23.3
 
-require github.com/stretchr/testify v1.9.0
+require github.com/stretchr/testify v1.10.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/match_test.go
+++ b/match_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (s *TestSuite) TestMultipleResponsesHasExpectedResponse() {
-	request := NewRequest(http.MethodPost, "/")
+	request := NewRequest().WithMethod(http.MethodPost).WithURL("/")
 	responses := Responses{NoContentResponse}
 
 	match := newConsumableResponsesMatch(request, responses)
@@ -14,7 +14,7 @@ func (s *TestSuite) TestMultipleResponsesHasExpectedResponse() {
 }
 
 func (s *TestSuite) TestMultipleResponsesRespondsTheCorrectNumberOfTimes() {
-	request := NewRequest(http.MethodPost, "/")
+	request := NewRequest().WithMethod(http.MethodPost).WithURL("/")
 
 	expectedFirstResponse := CreatedResponse
 	expectedSecondResponse := NoContentResponse

--- a/request_test.go
+++ b/request_test.go
@@ -7,11 +7,29 @@ import (
 )
 
 func (s *TestSuite) TestEqualityWorks() {
-	r := httpregistry.NewRequest(
-		"test",
-		http.MethodPatch,
-		httpregistry.WithRequestHeader("foo", "bar"),
-	)
+	var testCases = []struct {
+		name           string
+		r1             httpregistry.Request
+		r2             httpregistry.Request
+		expectedResult bool
+	}{
+		{
+			"equality works with default",
+			httpregistry.NewRequest(),
+			httpregistry.NewRequest(),
+			true,
+		},
+		{
+			"equality works with URL, method and header",
+			httpregistry.NewRequest().WithURL("/test").WithMethod(http.MethodPatch).WithHeader("foo", "bar"),
+			httpregistry.NewRequest().WithURL("/test").WithMethod(http.MethodPatch).WithHeader("foo", "bar"),
+			true,
+		},
+	}
 
-	s.True(r.Equal(r))
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.True(tc.r1.Equal(tc.r2))
+		})
+	}
 }

--- a/response.go
+++ b/response.go
@@ -1,13 +1,91 @@
 package httpregistry
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
+
+// The list of all status codes is available at
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+
+// Information responses
+var (
+	ContinueResponse           = NewResponse().WithStatus(100)
+	SwitchingProtocolsResponse = NewResponse().WithStatus(101)
+	ProcessingResponse         = NewResponse().WithStatus(102)
+	EarlyHintsResponse         = NewResponse().WithStatus(103)
+)
+
+// Successful responses
+var (
+	OkResponse                          = NewResponse().WithStatus(200)
+	CreatedResponse                     = NewResponse().WithStatus(201)
+	AcceptedResponse                    = NewResponse().WithStatus(202)
+	NonAuthoritativeInformationResponse = NewResponse().WithStatus(203)
+	NoContentResponse                   = NewResponse().WithStatus(204)
+	ResetContentResponse                = NewResponse().WithStatus(205)
+	PartialContentResponse              = NewResponse().WithStatus(206)
+	MultiStatusResponse                 = NewResponse().WithStatus(207)
+	AlreadyReportedResponse             = NewResponse().WithStatus(208)
+)
+
+// Redirection messages
+var (
+	MultipleChoicesResponse   = NewResponse().WithStatus(300)
+	MovedPermanentlyResponse  = NewResponse().WithStatus(301)
+	FoundResponse             = NewResponse().WithStatus(302)
+	SeeOtherResponse          = NewResponse().WithStatus(303)
+	NotModifiedResponse       = NewResponse().WithStatus(304)
+	TemporaryRedirectResponse = NewResponse().WithStatus(307)
+	PermanentRedirectResponse = NewResponse().WithStatus(308)
+)
+
+// Client error responses
+var (
+	BadRequestsResponse                 = NewResponse().WithStatus(400)
+	UnauthorizedResponse                = NewResponse().WithStatus(401)
+	PaymentRequiredResponse             = NewResponse().WithStatus(402)
+	ForbiddenResponse                   = NewResponse().WithStatus(403)
+	NotFoundResponse                    = NewResponse().WithStatus(404)
+	MethodNotAllowedResponse            = NewResponse().WithStatus(405)
+	NotAcceptableResponse               = NewResponse().WithStatus(406)
+	ProxyAuthenticationRequiredResponse = NewResponse().WithStatus(407)
+	RequestTimeoutResponse              = NewResponse().WithStatus(408)
+	ConflictResponse                    = NewResponse().WithStatus(409)
+	GoneResponse                        = NewResponse().WithStatus(410)
+	LengthRequiredResponse              = NewResponse().WithStatus(411)
+	PreconditionFailedResponse          = NewResponse().WithStatus(412)
+	PayloadTooLargeResponse             = NewResponse().WithStatus(413)
+	URITooLongResponse                  = NewResponse().WithStatus(414)
+	UnsupportedMediaTypeResponse        = NewResponse().WithStatus(415)
+	RangeNotSatisfiableResponse         = NewResponse().WithStatus(416)
+	ExpectationFailedResponse           = NewResponse().WithStatus(417)
+	IAmATeapotResponse                  = NewResponse().WithStatus(418)
+	MisdirectedRequestResponse          = NewResponse().WithStatus(421)
+	UpgradeRequiredResponse             = NewResponse().WithStatus(426)
+	ReconditionRequiredResponse         = NewResponse().WithStatus(428)
+	RequestHeaderFieldsTooLargeResponse = NewResponse().WithStatus(431)
+	UnavailableForLegalReasonsResponse  = NewResponse().WithStatus(451)
+)
+
+// Server error responses
+var (
+	InternalServerErrorResponse     = NewResponse().WithStatus(500)
+	NotImplementedResponse          = NewResponse().WithStatus(501)
+	BadGatewayResponse              = NewResponse().WithStatus(502)
+	ServiceUnavailableResponse      = NewResponse().WithStatus(503)
+	GatewayTimeoutResponse          = NewResponse().WithStatus(504)
+	HTTPVersionNotSupportedResponse = NewResponse().WithStatus(505)
+	VariantAlsoNegotiatesResponse   = NewResponse().WithStatus(506)
+	NotExtendedResponse             = NewResponse().WithStatus(510)
+	NetworkAuthenticationResponse   = NewResponse().WithStatus(511)
+)
 
 // Response represents a response that we want to return if the registry finds a request that matches the incoming request.
 // If the match happens then we will return a http response that matches the attributes defined in this struct.
 type Response struct {
-	Status  int               `json:"status"`
-	Body    []byte            `json:"body,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
+	StatusCode int               `json:"status_code"`
+	Body       []byte            `json:"body,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty"`
 }
 
 func (r Response) String() string {
@@ -18,138 +96,55 @@ func (r Response) String() string {
 	return string(bytes)
 }
 
-// Responses represents a slices of responses
-type Responses = []Response
-
-// ResponseOption represents a option that can be passed to NewResponse when creating a new response.
-// NewResponse uses the Option patters to make it easy to configure the response behavior.
-// For example
-//
-//	NewResponse(100, nil, WithResponseHeader("Content-Type", "application/json"))
-//
-// will return a response with the desired content type
-type ResponseOption func(*Response)
-
-// The list of all status codes is available at
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
-
-// Information responses
-var (
-	ContinueResponse           = NewResponse(100, nil)
-	SwitchingProtocolsResponse = NewResponse(101, nil)
-	ProcessingResponse         = NewResponse(102, nil)
-	EarlyHintsResponse         = NewResponse(103, nil)
-)
-
-// Successful responses
-var (
-	OkResponse                          = NewResponse(200, nil)
-	CreatedResponse                     = NewResponse(201, nil)
-	AcceptedResponse                    = NewResponse(202, nil)
-	NonAuthoritativeInformationResponse = NewResponse(203, nil)
-	NoContentResponse                   = NewResponse(204, nil)
-	ResetContentResponse                = NewResponse(205, nil)
-	PartialContentResponse              = NewResponse(206, nil)
-	MultiStatusResponse                 = NewResponse(207, nil)
-	AlreadyReportedResponse             = NewResponse(208, nil)
-)
-
-// Redirection messages
-var (
-	MultipleChoicesResponse   = NewResponse(300, nil)
-	MovedPermanentlyResponse  = NewResponse(301, nil)
-	FoundResponse             = NewResponse(302, nil)
-	SeeOtherResponse          = NewResponse(303, nil)
-	NotModifiedResponse       = NewResponse(304, nil)
-	TemporaryRedirectResponse = NewResponse(307, nil)
-	PermanentRedirectResponse = NewResponse(308, nil)
-)
-
-// Client error responses
-var (
-	BadRequestsResponse                 = NewResponse(400, nil)
-	UnauthorizedResponse                = NewResponse(401, nil)
-	PaymentRequiredResponse             = NewResponse(402, nil)
-	ForbiddenResponse                   = NewResponse(403, nil)
-	NotFoundResponse                    = NewResponse(404, nil)
-	MethodNotAllowedResponse            = NewResponse(405, nil)
-	NotAcceptableResponse               = NewResponse(406, nil)
-	ProxyAuthenticationRequiredResponse = NewResponse(407, nil)
-	RequestTimeoutResponse              = NewResponse(408, nil)
-	ConflictResponse                    = NewResponse(409, nil)
-	GoneResponse                        = NewResponse(410, nil)
-	LengthRequiredResponse              = NewResponse(411, nil)
-	PreconditionFailedResponse          = NewResponse(412, nil)
-	PayloadTooLargeResponse             = NewResponse(413, nil)
-	URITooLongResponse                  = NewResponse(414, nil)
-	UnsupportedMediaTypeResponse        = NewResponse(415, nil)
-	RangeNotSatisfiableResponse         = NewResponse(416, nil)
-	ExpectationFailedResponse           = NewResponse(417, nil)
-	IAmATeapotResponse                  = NewResponse(418, nil)
-	MisdirectedRequestResponse          = NewResponse(421, nil)
-	UpgradeRequiredResponse             = NewResponse(426, nil)
-	ReconditionRequiredResponse         = NewResponse(428, nil)
-	RequestHeaderFieldsTooLargeResponse = NewResponse(431, nil)
-	UnavailableForLegalReasonsResponse  = NewResponse(451, nil)
-)
-
-// Server error responses
-var (
-	InternalServerErrorResponse     = NewResponse(500, nil)
-	NotImplementedResponse          = NewResponse(501, nil)
-	BadGatewayResponse              = NewResponse(502, nil)
-	ServiceUnavailableResponse      = NewResponse(503, nil)
-	GatewayTimeoutResponse          = NewResponse(504, nil)
-	HTTPVersionNotSupportedResponse = NewResponse(505, nil)
-	VariantAlsoNegotiatesResponse   = NewResponse(506, nil)
-	NotExtendedResponse             = NewResponse(510, nil)
-	NetworkAuthenticationResponse   = NewResponse(511, nil)
-)
-
-// WithResponseHeader allows to add any header to a response.
-// If multiple headers with the same name are defined only the last one is applied.
-// To define multiple headers it is recommended to use WithResponseHeaders but it is possible to chain multiple calls of WithResponseHeader.
-func WithResponseHeader(header string, value string) func(*Response) {
-	return func(r *Response) {
-		r.Headers[header] = value
-	}
+// WithStatus returns a new response with the StatusCode attribute set to statusCode
+func (r Response) WithStatus(statusCode int) Response {
+	r.StatusCode = statusCode
+	return r
 }
 
-// WithResponseHeaders allows to add any number of headers to a response.
-// If multiple headers with the same name are defined only the last one is applied.
-func WithResponseHeaders(headers map[string]string) ResponseOption {
-	return func(r *Response) {
-		for k, v := range headers {
-			r.Headers[k] = v
-		}
-	}
+// WithHeader returns a new response with the header header set to value
+func (r Response) WithHeader(header string, value string) Response {
+	r.Headers[header] = value
+	return r
 }
 
-// NewJSONResponse creates a new Response with the desired statusCode, body and the various options applied,
-// whose "Content-Type" header is set to "application/json".
-// The JSON content type will overwrite any "Content-Type" header that is set via options.
-func NewJSONResponse(statusCode int, body []byte, options ...ResponseOption) Response {
-	r := Response{
-		Status:  statusCode,
-		Body:    body,
-		Headers: make(map[string]string),
-	}
-	for _, o := range options {
-		o(&r)
-	}
+// WithJSONHeader returns a new Response with the header `Content-Type` set to `application/json`
+func (r Response) WithJSONHeader() Response {
 	r.Headers["Content-Type"] = "application/json"
 	return r
 }
 
-// NewResponse creates a new Response with the desired statusCode, body and the various options applied.
-func NewResponse(statusCode int, body []byte, options ...func(*Response)) Response {
-	r := Response{
-		Status:  statusCode,
-		Body:    body,
-		Headers: make(map[string]string),
+// WithHeaders returns a new response with all the headers in headers applied.
+// If multiple headers with the same name are defined only the last one is applied.
+func (r Response) WithHeaders(headers map[string]string) Response {
+	for k, v := range headers {
+		r.Headers[k] = v
 	}
-	for _, o := range options {
-		o(&r)
+	return r
+}
+
+// WithBody returns a new request with the method body set to body
+func (r Response) WithBody(body []byte) Response {
+	r.Body = body
+	return r
+}
+
+// Responses represents a slices of responses
+type Responses = []Response
+
+// NewResponse creates a new Response.
+// This function is designed to be used in conjunction with other other receivers.
+// For example
+//
+//	NewResponse().
+//		WithStatus(http.StatusOK).
+//		WithJSONHeader().
+//		WithBody([]byte("{\"user\": \"John Schmidt\"}"))
+func NewResponse() Response {
+	r := Response{
+		StatusCode: 0,
+		Body:       make([]byte, 0),
+		Headers:    make(map[string]string),
 	}
 
 	return r


### PR DESCRIPTION
- Allow partial matches. Now it is possible to match requests only on part of a request like a header or the body.
- Move away from option patter since it does not make for a good user experience. We decided instead to use a factory pattern to create the various structs.
- Renamed some fuctions for clarity
- Update tests
- Update documentation