### PR TITLE
chore: update golangci.yaml to v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,15 +18,15 @@ jobs:
           - oldstable
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v6.0.1
+      uses: golangci/golangci-lint-action@v8.0.0
       with:
         skip-cache: true
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v5.5.0
       with:
         go-version: ${{ matrix.go_version }}
         cache: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,28 +1,35 @@
-output:
-  # sorts results by: filepath, line and column
-  sort-results: true
+version: "2"
 
 linters:
   enable:
-    - revive # general purpose linter, drop-in replacement for golint + some extra
-    - whitespace # checks for unnecessary newlines and trailing spaces
-    - unconvert # check for unnecessary type conversions
-    - promlinter # checks that prometheus metrics follow prometheus naming conventions, see https://prometheus.io/docs/practices/naming/
-    - nilerr # checks for cases where a nil value is returned even though a checked error is non-nil
-    - gofmt # basic gofmt + the simplification flag "-s"
-    - unparam # reports unused function parameters
-    - goimports # reformats imports respecting the local prefix defined below
+    - nilerr
+    - promlinter
+    - revive
+    - unconvert
+    - unparam
+    - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - revive
+        text: package-comments
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
-linters-settings:
-  goimports:
-    local-prefixes: github.com/dfioravanti/httpregistry
-
-issues:
-  exclude-use-default: false
-  exclude-rules:
-    - linters:
-        - revive
-      text: package-comments
-
-run:
-  timeout: 2m
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/dfioravanti/httpregistry
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
- Update golangci.yaml to v2
- Update github workflows to support golangci-lint > 2.0