### PR TITLE
feat: add JSON helper responses

### DIFF
--- a/response.go
+++ b/response.go
@@ -2,6 +2,7 @@ package httpregistry
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // The list of all status codes is available at
@@ -129,6 +130,27 @@ func (r Response) WithBody(body []byte) Response {
 	return r
 }
 
+// WithJSONBody returns a new response that will return body as body and will have
+// the header `Content-Type` set to `application/json`
+func (r Response) WithJSONBody(body string) Response {
+	r = r.WithJSONHeader()
+	r.Body = []byte(body)
+	return r
+}
+
+// WithJSONMarshalerBody returns a new response that will return body as body.MarshalJSON() and will have
+// the header `Content-Type` set to `application/json`.
+// This method will panic if MarshalJSON fails
+func (r Response) WithJSONMarshalerBody(body json.Marshaler) Response {
+	r = r.WithJSONHeader()
+	bodyAsString, err := body.MarshalJSON()
+	if err != nil {
+		panic(fmt.Sprintf("body cannot be marshaled to JSON: %s", err.Error()))
+	}
+	r.Body = bodyAsString
+	return r
+}
+
 // Responses represents a slices of responses
 type Responses = []Response
 
@@ -140,9 +162,11 @@ type Responses = []Response
 //		WithStatus(http.StatusOK).
 //		WithJSONHeader().
 //		WithBody([]byte("{\"user\": \"John Schmidt\"}"))
+//
+// The default response is a 200 without any body nor header
 func NewResponse() Response {
 	r := Response{
-		StatusCode: 0,
+		StatusCode: 200,
 		Body:       make([]byte, 0),
 		Headers:    make(map[string]string),
 	}

--- a/response_test.go
+++ b/response_test.go
@@ -1,0 +1,64 @@
+package httpregistry
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type typeMarshable struct {
+	A int `json:"a"`
+}
+
+func (t typeMarshable) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("{\"a\": %d}", t.A)), nil
+}
+
+func (s *TestSuite) TestCustomResponseReturnsExpectedHeadersAndBody() {
+	testCases := []struct {
+		name            string
+		response        Response
+		expectedBody    string
+		expectedHeaders http.Header
+	}{
+		{
+			name:            "json response works",
+			response:        NewResponse().WithJSONBody("{\"a\": 10}"),
+			expectedBody:    "{\"a\": 10}",
+			expectedHeaders: map[string][]string{"Content-Type": {"application/json"}},
+		},
+		{
+			name:            "json marshaler response works",
+			response:        NewResponse().WithJSONMarshalerBody(typeMarshable{A: 10}),
+			expectedBody:    "{\"a\": 10}",
+			expectedHeaders: map[string][]string{"Content-Type": {"application/json"}},
+		},
+	}
+	for _, tc := range testCases {
+		method := http.MethodGet
+		path := "/test"
+		request := NewRequest().WithMethod(method).WithURL(path)
+		client := http.Client{}
+
+		s.Run(tc.name, func() {
+			registry := NewRegistry(s.T())
+			registry.AddRequestWithResponse(request, tc.response)
+
+			server := registry.GetServer()
+			defer server.Close()
+
+			request, err := http.NewRequest(method, server.URL+path, nil)
+			s.NoError(err)
+
+			res, err := client.Do(request)
+			s.NoError(err)
+
+			body, err := io.ReadAll(res.Body)
+			s.NoError(err)
+
+			s.Equal(res.StatusCode, 200)
+			s.Equal(tc.expectedBody, string(body))
+			s.Subset(res.Header, tc.expectedHeaders)
+		})
+	}
+}


### PR DESCRIPTION
- Added WithJSONBody and WithJSONMarshalerBody to simplify creating a response with a JSON body.
- Set 200 as default status code for a response since 0 makes no sense and will crash the tests