### PR TITLE
chore: allow for custom responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,71 @@ Once a request is matched the corresponding `Response` is used to determine what
 * Body
 * Headers
 
+### Custom responses
+
+Sometimes the standard `Response` from the package is not enough, suppose that you want to return a different value depending on the request, so for example you want to match an ID in the path or something similar. This is not possible with a `Response` since it does not allow to interact with the `http.Request` that is coming in. To solve this problem this package provides a `CustomResponse` type that allows you to interact with both the `http.Request` and the `http.ResponseWriter`.
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/dfioravanti/httpregistry"
+)
+
+func TestCustomRequestWorks(t *testing.T) {
+    // 1. Create the registry and defer the check that all responses
+	//    that we will create are used.
+	//    t is used to fail the test if the deferred check fails.
+	registry := httpregistry.NewRegistry(t)
+	defer registry.CheckAllResponsesAreConsumed()
+
+	// 2. Create a CustomResponse, all functions that accept Response also accept CustomResponse
+	mockResponse := httpregistry.NewCustomResponse(func(w http.ResponseWriter, r *http.Request) {
+		regexUser := regexp.MustCompile(`/users/(?P<userID>.+)/address$`)
+		if regexUser.MatchString(r.URL.Path) {
+			matches := regexUser.FindStringSubmatch(r.URL.Path)
+			userID := matches[regexUser.SubexpIndex("userID")]
+			body := map[string]string{"user_id": userID}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(&body)
+			return
+		}
+	})
+	// Optional add a name to the CustomResponse so it is easier to debug, by default they get "custom response 1,2,3" as name
+	mockResponse = mockResponse.WithName("match on user ID")
+	registry.AddResponse(mockResponse)
+
+	// 3. Create the server
+	server := registry.GetServer()
+	defer server.Close()
+
+	// 4. Make calls and check assertions
+	response, err := http.Get(server.URL + "/users/12/address")
+	if err != nil {
+		t.Errorf("executing request failed: %v", err)
+	}
+	if response.StatusCode != 200 {
+		t.Errorf("unexpected status code %v", response.StatusCode)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Errorf("reading body failed: %v", err)
+	}
+
+	expectedBody := "{\"user_id\":\"12\"}\n"
+	if string(body) != expectedBody {
+		t.Errorf("body does not match expected body")
+	}
+}
+```
+
 ## How is a request selected
 
 In case multiple requests match the incoming one then the first one, by order of registration, matching that still has unconsumed responses will be selected. So for example

--- a/docs.go
+++ b/docs.go
@@ -31,5 +31,7 @@ With this library this can be done as
 		WithJSONHeader().
 		WithBody([]byte("{\"user\": \"John Schmidt\"}"))
 	ts := registry.GetServer()
+
+For more examples of what this package is capable of, refer to the README file.
 */
 package httpregistry

--- a/docs_test.go
+++ b/docs_test.go
@@ -1,7 +1,10 @@
 package httpregistry_test
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
+	"regexp"
 	"testing"
 
 	"github.com/dfioravanti/httpregistry"
@@ -64,5 +67,52 @@ func TestMultipleMatchingWorks(t *testing.T) {
 	}
 	if response.StatusCode != 404 {
 		t.Errorf("unexpected status code %v", response.StatusCode)
+	}
+}
+
+func TestCustomRequestWorks(t *testing.T) {
+	// 1. Create the registry and defer the check that all responses
+	//    that we will create are used.
+	//    t is used to fail the test if the deferred check fails.
+	registry := httpregistry.NewRegistry(t)
+	defer registry.CheckAllResponsesAreConsumed()
+
+	// 2. Create a CustomResponse, all functions that accept Response also accept CustomResponse
+	mockResponse := httpregistry.NewCustomResponse(func(w http.ResponseWriter, r *http.Request) {
+		regexUser := regexp.MustCompile(`/users/(?P<userID>.+)/address$`)
+		if regexUser.MatchString(r.URL.Path) {
+			matches := regexUser.FindStringSubmatch(r.URL.Path)
+			userID := matches[regexUser.SubexpIndex("userID")]
+			body := map[string]string{"user_id": userID}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(&body)
+			return
+		}
+	})
+	// Optional add a name to the CustomResponse so it is easier to debug, by default they get "custom response 1,2,3" as name
+	mockResponse = mockResponse.WithName("match on user ID")
+	registry.AddResponse(mockResponse)
+
+	// 3. Create the server
+	server := registry.GetServer()
+	defer server.Close()
+
+	// 4. Make calls and check assertions
+	response, err := http.Get(server.URL + "/users/12/address")
+	if err != nil {
+		t.Errorf("executing request failed: %v", err)
+	}
+	if response.StatusCode != 200 {
+		t.Errorf("unexpected status code %v", response.StatusCode)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Errorf("reading body failed: %v", err)
+	}
+
+	expectedBody := "{\"user_id\":\"12\"}\n"
+	if string(body) != expectedBody {
+		t.Errorf("body does not match expected body")
 	}
 }

--- a/match.go
+++ b/match.go
@@ -18,7 +18,7 @@ type match interface {
 	RecordMatch(req *http.Request)
 	// Next response returns the next response associated with the match and records which request triggered the match.
 	// If the list of responses is exhausted it will return a ErrNoNextResponseFound error
-	NextResponse() (Response, error)
+	NextResponse() (mockResponse, error)
 	// NumberOfCalls returns the number of times the match was fulfilled
 	NumberOfCalls() int
 	// Matches returns the list of http.Request that matched with this Match
@@ -29,13 +29,13 @@ type match interface {
 // Important: the list of responses gets consumed by the server. Do not reuse this structure, create a new one
 type consumableResponsesMatch struct {
 	request       Request
-	responses     Responses
+	responses     mockResponses
 	numberOfCalls int
 	matches       []*http.Request
 }
 
 // newConsumableResponsesMatch creates a new consumableResponsesMatch
-func newConsumableResponsesMatch(request Request, responses Responses) *consumableResponsesMatch {
+func newConsumableResponsesMatch(request Request, responses mockResponses) *consumableResponsesMatch {
 	return &consumableResponsesMatch{
 		request:       request,
 		responses:     responses,
@@ -57,9 +57,9 @@ func (m *consumableResponsesMatch) RecordMatch(req *http.Request) {
 // Next response returns the next response associated with the match.
 // If the list of responses is exhausted it will return a ErrNoNextResponseFound error
 // It consumes the list associated with the MultipleResponsesMatch
-func (m *consumableResponsesMatch) NextResponse() (Response, error) {
+func (m *consumableResponsesMatch) NextResponse() (mockResponse, error) {
 	if len(m.responses) == 0 {
-		return Response{}, errNoNextResponseFound
+		return nil, errNoNextResponseFound
 	}
 
 	head, tail := m.responses[0], m.responses[1:]

--- a/match_test.go
+++ b/match_test.go
@@ -6,7 +6,7 @@ import (
 
 func (s *TestSuite) TestMultipleResponsesHasExpectedResponse() {
 	request := NewRequest().WithMethod(http.MethodPost).WithURL("/")
-	responses := Responses{NoContentResponse}
+	responses := mockResponses{NoContentResponse}
 
 	match := newConsumableResponsesMatch(request, responses)
 
@@ -18,7 +18,7 @@ func (s *TestSuite) TestMultipleResponsesRespondsTheCorrectNumberOfTimes() {
 
 	expectedFirstResponse := CreatedResponse
 	expectedSecondResponse := NoContentResponse
-	responses := Responses{expectedFirstResponse, expectedSecondResponse}
+	responses := mockResponses{expectedFirstResponse, expectedSecondResponse}
 
 	match := newConsumableResponsesMatch(request, responses)
 

--- a/registry.go
+++ b/registry.go
@@ -35,7 +35,7 @@ func NewRegistry(t TestingT) *Registry {
 // will create a http server that returns 200 on calling anything.
 func (reg *Registry) Add() {
 	request := NewRequest()
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{OkResponse}))
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{OkResponse}))
 }
 
 // AddURL adds to the registry a 200 response for a request that matches the URL
@@ -47,7 +47,7 @@ func (reg *Registry) Add() {
 // will create a http server that returns 200 on calling GET "/foo" and fails the test on anything else
 func (reg *Registry) AddURL(URL string) {
 	request := NewRequest().WithURL(URL)
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{OkResponse}))
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{OkResponse}))
 }
 
 // AddURLWithStatusCode adds to the registry a statusCode response for a request that matches the URL
@@ -61,7 +61,7 @@ func (reg *Registry) AddURLWithStatusCode(URL string, statusCode int) {
 	request := NewRequest().WithURL(URL)
 	response := NewResponse().WithStatus(statusCode)
 
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{response}))
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{response}))
 }
 
 // AddMethod adds to the registry a 200 response for a request that matches the method
@@ -73,7 +73,7 @@ func (reg *Registry) AddURLWithStatusCode(URL string, statusCode int) {
 // will create a http server that returns 200 on calling GET "/foo" and fails the test on anything else
 func (reg *Registry) AddMethod(method string) {
 	request := NewRequest().WithMethod(method)
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{OkResponse}))
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{OkResponse}))
 }
 
 // AddMethodWithStatusCode adds to the registry a statusCode response for a request that matches the method
@@ -86,7 +86,7 @@ func (reg *Registry) AddMethod(method string) {
 func (reg *Registry) AddMethodWithStatusCode(method string, statusCode int) {
 	request := NewRequest().WithMethod(method)
 	response := NewResponse().WithStatus(statusCode)
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{response}))
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{response}))
 }
 
 // AddMethodAndURL adds to the registry a 200 response for a request that matches method and URL
@@ -98,7 +98,7 @@ func (reg *Registry) AddMethodWithStatusCode(method string, statusCode int) {
 // will create a http server that returns 200 on calling GET "/foo" and fails the test on anything else
 func (reg *Registry) AddMethodAndURL(method string, URL string) {
 	request := NewRequest().WithMethod(method).WithURL(URL)
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{OkResponse}))
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{OkResponse}))
 }
 
 // AddMethodAndURLWithStatusCode adds to the registry a statusCode response for a request that matches method and URL
@@ -112,7 +112,7 @@ func (reg *Registry) AddMethodAndURLWithStatusCode(method string, URL string, st
 	request := NewRequest().WithMethod(method).WithURL(URL)
 	response := NewResponse().WithStatus(statusCode)
 
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{response}))
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{response}))
 }
 
 // AddBody adds to the registry a statusCode response for a request that matches method and URL
@@ -124,7 +124,7 @@ func (reg *Registry) AddMethodAndURLWithStatusCode(method string, URL string, st
 // will create a http server that returns 204 on calling GET "/foo" and fails the test on anything else
 func (reg *Registry) AddBody(body []byte) {
 	request := NewRequest().WithBody(body)
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{OkResponse}))
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{OkResponse}))
 }
 
 // AddRequest adds to the registry a 200 response for a generic request that needs to be matched
@@ -137,7 +137,36 @@ func (reg *Registry) AddBody(body []byte) {
 //
 // will create a http server that returns 200 on calling GET "/foo" with the correct header and fails the test on anything else
 func (reg *Registry) AddRequest(request Request) {
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{OkResponse}))
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{OkResponse}))
+}
+
+// AddResponse adds to the registry a generic response that is returned for any call
+//
+//	reg := httpregistry.NewRegistry(t)
+//	reg.AddResponse(
+//		httpregistry.NewResponse(http.StatusCreated, []byte{"hello"}),
+//	)
+//	reg.GetServer()
+//
+// will create a http server that returns 204 with "hello" as body on calling the server on any URL
+func (reg *Registry) AddResponse(response mockResponse) {
+	request := NewRequest()
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{response}))
+}
+
+// AddResponses adds to the registry a generic response that is returned for any call
+//
+//		reg := httpregistry.NewRegistry(t)
+//		reg.AddResponses(
+//			httpregistry.NewResponse(http.StatusCreated, []byte{"hello"}),
+//	     httpregistry.NewResponse(http.StatusCreated, []byte{"hello"}),
+//		)
+//		reg.GetServer()
+//
+// will create a http server that returns 204 with "hello" as body on calling the server on any URL for two times and then returns an error
+func (reg *Registry) AddResponses(responses ...mockResponse) {
+	request := NewRequest()
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, responses))
 }
 
 // AddRequestWithResponse adds to the registry a generic response for a generic request that needs to be matched
@@ -150,8 +179,8 @@ func (reg *Registry) AddRequest(request Request) {
 //	reg.GetServer()
 //
 // will create a http server that returns 204 with "hello" as body on calling GET "/foo" with the correct header and fails the test on anything else
-func (reg *Registry) AddRequestWithResponse(request Request, response Response) {
-	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, []Response{response}))
+func (reg *Registry) AddRequestWithResponse(request Request, response mockResponse) {
+	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, mockResponses{response}))
 }
 
 // AddRequestWithResponses adds to the registry multiple responses for a generic request that needs to be matched.
@@ -167,7 +196,7 @@ func (reg *Registry) AddRequestWithResponse(request Request, response Response) 
 //
 // will create a http server that returns 204 with "hello" as body on calling GET "/foo" the first call with the correct header,
 // it returns 200 with "hello again" as body on the second call with the correct header and fails the test on anything else
-func (reg *Registry) AddRequestWithResponses(request Request, responses ...Response) {
+func (reg *Registry) AddRequestWithResponses(request Request, responses ...mockResponse) {
 	reg.matches = append(reg.matches, newConsumableResponsesMatch(request, responses))
 }
 
@@ -284,15 +313,7 @@ func (reg *Registry) GetServer() *httptest.Server {
 			}
 
 			possibleMatch.RecordMatch(r)
-
-			for k, v := range response.Headers {
-				w.Header().Add(k, v)
-			}
-			w.WriteHeader(response.StatusCode)
-			_, err = w.Write(response.Body)
-			if err != nil {
-				panic("cannot write body of request")
-			}
+			response.createResponse(w, r)
 			return
 		}
 

--- a/response_custom.go
+++ b/response_custom.go
@@ -1,0 +1,75 @@
+package httpregistry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// this is a bit of hacky thing to have a default name
+var counter = 0
+
+// CustomResponse allows the user to define a custom made response to any request.
+// In particular it allows to define responses that are functions of the request
+//
+// for example
+//
+//	func(w http.ResponseWriter, r *http.Request) {
+//		regexUser := regexp.MustCompile(`/users/(?P<userID>.+)/address$`)
+//		if regexUser.MatchString(r.URL.Path) {
+//			matches := regexUser.FindStringSubmatch(r.URL.Path)
+//			userID := matches[regexUser.SubexpIndex("userID")]
+//			body := map[string]string{"user_id": userID}
+//			w.Header().Set("Content-Type", "application/json")
+//			_ = json.NewEncoder(w).Encode(&body)
+//			return
+//		}
+//	}
+type CustomResponse struct {
+	Name string `json:"name,omitempty"`
+	f    func(w http.ResponseWriter, r *http.Request)
+}
+
+// String marshal FunctionalResponse to string
+func (res CustomResponse) String() string {
+	bytes, err := json.Marshal(res)
+	if err != nil {
+		panic("cannot marshal request")
+	}
+	return string(bytes)
+}
+
+// createResponse emits the response encoded in FunctionalResponse to w
+func (res CustomResponse) createResponse(w http.ResponseWriter, r *http.Request) {
+	res.f(w, r)
+}
+
+// WithName allows to add a name to a FunctionalResponse so that it can be better identified when debugging.
+// By the fault FunctionalResponse gets a sequential name that can be hard to identify if there are many of them
+func (res CustomResponse) WithName(name string) CustomResponse {
+	res.Name = name
+	return res
+}
+
+// NewCustomResponse creates a new FunctionalResponse.
+// A FunctionalResponse allows the user to define a custom made response to any request.
+// In particular it allows to define responses that are functions of the request
+//
+// for example
+//
+//	func(w http.ResponseWriter, r *http.Request) {
+//		regexUser := regexp.MustCompile(`/users/(?P<userID>.+)/address$`)
+//		if regexUser.MatchString(r.URL.Path) {
+//			matches := regexUser.FindStringSubmatch(r.URL.Path)
+//			userID := matches[regexUser.SubexpIndex("userID")]
+//			body := map[string]string{"user_id": userID}
+//			w.Header().Set("Content-Type", "application/json")
+//			_ = json.NewEncoder(w).Encode(&body)
+//			return
+//		}
+//	}
+func NewCustomResponse(f func(w http.ResponseWriter, r *http.Request)) CustomResponse {
+	res := CustomResponse{Name: fmt.Sprintf("Custom response %d", counter), f: f}
+	counter++
+	return res
+}

--- a/response_custom_test.go
+++ b/response_custom_test.go
@@ -1,0 +1,59 @@
+package httpregistry
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+)
+
+func (s *TestSuite) TestFunctionalResponse() {
+	testCases := []struct {
+		name         string
+		request      Request
+		response     CustomResponse
+		expectedBody string
+	}{
+		{
+			name: "extract user id works",
+			request: NewRequest().
+				WithURL("users/12/address"),
+			response: NewCustomResponse(func(w http.ResponseWriter, r *http.Request) {
+				regexUser := regexp.MustCompile(`/users/(?P<userID>.+)/address$`)
+				if regexUser.MatchString(r.URL.Path) {
+					matches := regexUser.FindStringSubmatch(r.URL.Path)
+					userID := matches[regexUser.SubexpIndex("userID")]
+					body := map[string]string{"user_id": userID}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(&body)
+					return
+				}
+			}),
+			expectedBody: "{\"user_id\":\"12\"}\n",
+		},
+	}
+	for _, tc := range testCases {
+		client := http.Client{}
+
+		s.Run(tc.name, func() {
+			registry := NewRegistry(s.T())
+			registry.AddRequestWithResponse(tc.request, tc.response)
+
+			server := registry.GetServer()
+			defer server.Close()
+
+			request, err := http.NewRequest(tc.request.Method, server.URL+"/"+tc.request.URL, bytes.NewReader(tc.request.Body))
+			s.NoError(err)
+
+			res, err := client.Do(request)
+			s.NoError(err)
+
+			body, err := io.ReadAll(res.Body)
+			s.NoError(err)
+
+			s.Equal(res.StatusCode, 200)
+			s.Equal(tc.expectedBody, string(body))
+		})
+	}
+}

--- a/response_interface.go
+++ b/response_interface.go
@@ -1,0 +1,17 @@
+package httpregistry
+
+import "net/http"
+
+// mockResponse represents all structs inside the httpregistry that can be used to define how a mocked response will look like.
+// Currently we have
+//
+//   - httpregistry.Response -> it allows to define (one or more) status code, body and headers
+//   - httpregistry.CustomResponse -> it allows to define the response as a function of (w, r)
+type mockResponse interface {
+	// createResponse emits the response encoded in the struct that implements mockResponse to w
+	createResponse(w http.ResponseWriter, r *http.Request)
+	// String Marshals the mockResponse into string
+	String() string
+}
+
+type mockResponses = []mockResponse


### PR DESCRIPTION
- Allow for custom responses to be returned instead of only standard responses that allow to manipulate only status code, body and header. A custom response is a function f(w http.ResponseWriter, r *http.Request) that allows complete control over what goes on in the server
- Extract a mockResponse interface that abstracts away both the standard and custom reponses
- Implemeted helper methods for custom responses
- Added tests
- Updated documentation