### PR TITLE
Feat: allow infinite responses

### DIFF
--- a/match.go
+++ b/match.go
@@ -77,3 +77,48 @@ func (m *consumableResponsesMatch) Matches() []*http.Request {
 func (m *consumableResponsesMatch) NumberOfCalls() int {
 	return len(m.matches)
 }
+
+// A infiniteResponsesMatch is a match that returns the same Response each time a predefined Request happens.
+// The response is never consumed, so NextResponse() never returns an errNoNextResponseFound
+type infiniteResponsesMatch struct {
+	request       Request
+	response      mockResponse
+	numberOfCalls int
+	matches       []*http.Request
+}
+
+// newInfiniteResponsesMatch creates a new infiniteResponsesMatch
+func newInfiniteResponsesMatch(request Request, response mockResponse) *infiniteResponsesMatch {
+	return &infiniteResponsesMatch{
+		request:       request,
+		response:      response,
+		numberOfCalls: 0,
+		matches:       make([]*http.Request, 0),
+	}
+}
+
+// Request returns the request that triggers the match
+func (m *infiniteResponsesMatch) Request() Request {
+	return m.request
+}
+
+// RecordMatch records that a request was a successful match for this match
+func (m *infiniteResponsesMatch) RecordMatch(req *http.Request) {
+	m.matches = append(m.matches, cloneHTTPRequest(req))
+}
+
+// Next response returns the next response associated with the match.
+// As this is an infinite match this function never returns an error
+func (m *infiniteResponsesMatch) NextResponse() (mockResponse, error) {
+	return m.response, nil
+}
+
+// Matches returns the list of http.Request that matched with this Match
+func (m *infiniteResponsesMatch) Matches() []*http.Request {
+	return m.matches
+}
+
+// NumberOfCalls returns the number of times the match was fulfilled
+func (m *infiniteResponsesMatch) NumberOfCalls() int {
+	return len(m.matches)
+}

--- a/registry.go
+++ b/registry.go
@@ -232,7 +232,15 @@ func (reg *Registry) AddRequestWithInfiniteResponse(request Request, response mo
 func (reg *Registry) GetMatchesForRequest(r Request) []*http.Request {
 	for _, match := range reg.matches {
 		if match.Request().Equal(r) {
-			return match.Matches()
+			matches := match.Matches()
+
+			// we clone the requests so that if this function is called multiple times things
+			// like the request body can be accessed again
+			matchesToReturn := make([]*http.Request, 0, len(matches))
+			for _, m := range matches {
+				matchesToReturn = append(matchesToReturn, cloneHTTPRequest(m))
+			}
+			return matchesToReturn
 		}
 	}
 	return []*http.Request{}
@@ -243,7 +251,15 @@ func (reg *Registry) GetMatchesForURL(url string) []*http.Request {
 	for _, match := range reg.matches {
 		r := match.Request()
 		if r.urlAsRegex.MatchString(url) {
-			return match.Matches()
+			matches := match.Matches()
+
+			// we clone the requests so that if this function is called multiple times things
+			// like the request body can be accessed again
+			matchesToReturn := make([]*http.Request, 0, len(matches))
+			for _, m := range matches {
+				matchesToReturn = append(matchesToReturn, cloneHTTPRequest(m))
+			}
+			return matchesToReturn
 		}
 	}
 	return []*http.Request{}
@@ -254,7 +270,15 @@ func (reg *Registry) GetMatchesURLAndMethod(url string, method string) []*http.R
 	for _, match := range reg.matches {
 		r := match.Request()
 		if r.urlAsRegex.MatchString(url) && r.Method == method {
-			return match.Matches()
+			matches := match.Matches()
+
+			// we clone the requests so that if this function is called multiple times things
+			// like the request body can be accessed again
+			matchesToReturn := make([]*http.Request, 0, len(matches))
+			for _, m := range matches {
+				matchesToReturn = append(matchesToReturn, cloneHTTPRequest(m))
+			}
+			return matchesToReturn
 		}
 	}
 	return []*http.Request{}

--- a/registry_test.go
+++ b/registry_test.go
@@ -281,6 +281,15 @@ func (s *TestSuite) TestAccessTheRequestBodyWorks() {
 	s.NoError(err)
 
 	s.Equal(expectedBody, bodyBytes)
+
+	// we check that the body is not consumed but it can be accessed again
+	matchingRequests = registry.GetMatchesForRequest(mockRequest)
+	s.Equal(1, len(matchingRequests))
+
+	bodyBytes, err = io.ReadAll(matchingRequests[0].Body)
+	s.NoError(err)
+
+	s.Equal(expectedBody, bodyBytes)
 }
 
 func (s *TestSuite) TestAccessTheRequestBodyByUrlWorks() {
@@ -316,6 +325,15 @@ func (s *TestSuite) TestAccessTheRequestBodyByUrlWorks() {
 	s.NoError(err)
 
 	s.Equal(expectedBody, bodyBytes)
+
+	// we check that the body is not consumed but it can be accessed again
+	matchingRequests = registry.GetMatchesForURL(path)
+	s.Equal(1, len(matchingRequests))
+
+	bodyBytes, err = io.ReadAll(matchingRequests[0].Body)
+	s.NoError(err)
+
+	s.Equal(expectedBody, bodyBytes)
 }
 
 func (s *TestSuite) TestAccessTheRequestBodyByUrlAndMethodWorks() {
@@ -348,6 +366,15 @@ func (s *TestSuite) TestAccessTheRequestBodyByUrlAndMethodWorks() {
 	s.Equal(1, len(matchingRequests))
 
 	bodyBytes, err := io.ReadAll(matchingRequests[0].Body)
+	s.NoError(err)
+
+	s.Equal(expectedBody, bodyBytes)
+
+	// we check that the body is not consumed but it can be accessed again
+	matchingRequests = registry.GetMatchesURLAndMethod(path, http.MethodPost)
+	s.Equal(1, len(matchingRequests))
+
+	bodyBytes, err = io.ReadAll(matchingRequests[0].Body)
 	s.NoError(err)
 
 	s.Equal(expectedBody, bodyBytes)

--- a/request.go
+++ b/request.go
@@ -6,6 +6,10 @@ import (
 	"regexp"
 )
 
+// DefaultRequest represents the request that is used when no request is specified.
+// This is useful in combination with registry.GetMatchesForRequest so that it is possible to retrieve all the matches associated with it
+var DefaultRequest = NewRequest()
+
 // Request represents a request that will be registered to a Registry to get matched against an incoming HTTP request.
 // The match happens against the method, the headers and the URL interpreted as a regex
 type Request struct {

--- a/request_test.go
+++ b/request_test.go
@@ -33,3 +33,10 @@ func (s *TestSuite) TestEqualityWorks() {
 		})
 	}
 }
+
+func (s *TestSuite) TestModifyingDefaultRequestDoesNotChangeOriginal() {
+	r := httpregistry.DefaultRequest
+	r = r.WithMethod(http.MethodPost)
+
+	s.False(httpregistry.DefaultRequest.Equal(r))
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,6 +3,7 @@ package httpregistry_test
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 )
 
 // mustMarshalJSON tries to marshal v into JSON and panics if it cannot
@@ -12,4 +13,14 @@ func mustMarshalJSON(v any) []byte {
 		panic(fmt.Sprintf("body cannot be marshaled to JSON: %s", err))
 	}
 	return b
+}
+
+// generateRandomString generates a random string of a given length.
+func generateRandomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
- By default a response is consumed when it is matched but sometimes we
  might want to avoid that. With this patch this possibility has been
  introduced.
- Before this fix we would directly return the *http.Request that would
  match a httpregistry.Request. This has the problem that if we modify
  the *http.Request (since it is a pointer) this would change the
  recorded value. To aboid this we clone the request before returning it
- Updated documentation
- Updated tests