### PR TITLE
feat: new naming scheme for request/response

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,124 @@ func TestCustomRequestWorks(t *testing.T) {
 }
 ```
 
+## Investigate failed tests
+
+The library tries to help as much as possible in debugging why a test has failed. To achieve this it will
+1. Fail a test if
+   1. It is impossible to reply to a request
+   2. `registry.CheckAllResponsesAreConsumed()` is called but not all the requests are consumed
+2. In case if it is impossible to reply to a request it will report in the body of the response why it failed
+3. Provide a `httpregistry.NewMockTestingT()` that can be passed in place of `*testing.T` so that test failures can be better analyzed
+
+### Investigate if a test fails to consume all requests
+```go
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/dfioravanti/httpregistry"
+)
+
+func TestHowToInvestigateFailingTest(t *testing.T) {
+	// 1. Setup a mock for testing.T that we control and can access later
+	mockT := httpregistry.NewMockTestingT()
+
+	// 2. Setup registry and the requests
+	registry := httpregistry.NewRegistry(mockT)
+	registry.AddMethodAndURL(http.MethodGet, "/foo")
+	registry.AddMethodAndURL(http.MethodDelete, "/bar")
+	registry.AddRequestWithResponse(
+		httpregistry.DefaultRequest,
+		httpregistry.NewResponse().WithName("My beautiful response"),
+	)
+	registry.AddRequestWithResponse(
+		httpregistry.DefaultRequest,
+		httpregistry.NewCustomResponse(func(w http.ResponseWriter, r *http.Request) {}).WithName("My beautiful custom response"),
+	)
+
+	// 3. No call happens but we assert that all calls were consumed
+	registry.CheckAllResponsesAreConsumed()
+
+	// 4. Let us check that mockT contains useful information
+	if len(mockT.Messages) != 4 {
+		t.Errorf("There should be 4 uncalled request but I found only %d", len(mockT.Messages))
+	}
+
+	if !slices.Contains(mockT.Messages, "request mock request #1 has httpregistry.OkResponse as unused response") {
+		t.Error("request mock request #1 has httpregistry.OkResponse as unused response should be in the slice but it is not")
+	}
+	if !slices.Contains(mockT.Messages, "request mock request #2 has httpregistry.OkResponse as unused response") {
+		t.Error("request mock request #2 has httpregistry.OkResponse as unused response should be in the slice but it is not")
+	}
+	if !slices.Contains(mockT.Messages, "request httpregistry.DefaultRequest has My beautiful response as unused response") {
+		t.Error("request httpregistry.DefaultRequest has My beautiful response as unused response should be in the slice but it is not")
+	}
+	if !slices.Contains(mockT.Messages, "request httpregistry.DefaultRequest has My beautiful custom response as unused response") {
+		t.Error("request httpregistry.DefaultRequest has My beautiful custom response as unused response should be in the slice but it is not")
+	}
+}
+```
+### Investigate why a test fails when calling
+
+```go
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/dfioravanti/httpregistry"
+)
+
+func TestWeCanInvestigateWhyATestFails(t *testing.T) {
+	// 1. Setup a mock for testing.T that we control and can access later
+	mockT := httpregistry.NewMockTestingT()
+
+	// 2. Setup registry and the requests
+	registry := httpregistry.NewRegistry(mockT)
+	registry.AddMethodAndURL(http.MethodGet, "/foo")
+
+	// 3. Call Twice a route with only one response
+	url := registry.GetServer().URL
+	client := http.Client{}
+
+	// 3a. First call works
+	firstResponse, err := client.Get(url + "/foo")
+	if err != nil {
+		t.Errorf("Unexpected error in first request: %s", err)
+	}
+	if firstResponse.StatusCode != 200 {
+		t.Errorf("Unexpected status code for first response, I was expecting 200 we got %d", firstResponse.StatusCode)
+	}
+
+	// 3b. Second call fails
+	secondResponse, err := client.Get(url + "/foo")
+	if err != nil {
+		t.Errorf("Unexpected error in second request: %s", err)
+	}
+	if secondResponse.StatusCode != 500 {
+		t.Errorf("Unexpected status code for second response, I was expecting 500 we got %d", secondResponse.StatusCode)
+	}
+
+	// 4. The test was failed
+	if mockT.HasFailed != true {
+		t.Errorf("mockT.HasFailed should be true, but it was %t", mockT.HasFailed)
+	}
+
+	// 5. The body of the call tells us why it failed
+	bodyBytes, err := io.ReadAll(secondResponse.Body)
+	if err != nil {
+		t.Errorf("Decoding second response body failed: %s", err)
+	}
+	body := string(bodyBytes)
+	if body != "mock request #1 missed because the route matches but there was no response available" {
+		t.Errorf("was expecting \"mock request #1 missed because the route matches but there was no response available\", got: %s", body)
+	}
+}
+```
+
 ## How is a request selected
 
 In case multiple requests match the incoming one then the first one, by order of registration, matching that still has unconsumed responses will be selected. So for example

--- a/misses.go
+++ b/misses.go
@@ -6,10 +6,10 @@ type whyMissed string
 
 // These constants are used to represents why a match does not work and they are returned to the user as part of the error message so that errors can be debugged easily
 const (
-	pathDoesNotMatch   = whyMissed("The path does not match")
-	methodDoesNotMatch = whyMissed("The method does not match")
-	headerDoesNotMatch = whyMissed("The header does not match")
-	outOfResponses     = whyMissed("The route matches but there was no response available")
+	pathDoesNotMatch   = whyMissed("the path does not match")
+	methodDoesNotMatch = whyMissed("the method does not match")
+	headerDoesNotMatch = whyMissed("the header does not match")
+	outOfResponses     = whyMissed("the route matches but there was no response available")
 )
 
 // miss represents that the registry was not able to match a registered request with the current request that is coming in from the outside.
@@ -37,5 +37,5 @@ func newMiss(match match, why whyMissed) miss {
 
 // String returns a human readable version of why the match could not happen
 func (m miss) String() string {
-	return fmt.Sprintf("%v missed %v", m.Request, m.Why)
+	return fmt.Sprintf("%v missed because %v", m.Request, m.Why)
 }

--- a/request.go
+++ b/request.go
@@ -1,47 +1,70 @@
 package httpregistry
 
 import (
-	"encoding/json"
 	"reflect"
 	"regexp"
 )
 
 // DefaultRequest represents the request that is used when no request is specified.
+// It will match any request.
 // This is useful in combination with registry.GetMatchesForRequest so that it is possible to retrieve all the matches associated with it
-var DefaultRequest = NewRequest()
+var DefaultRequest = newRequestWithName("httpregistry.DefaultRequest")
 
 // Request represents a request that will be registered to a Registry to get matched against an incoming HTTP request.
 // The match happens against the method, the headers and the URL interpreted as a regex
 type Request struct {
-	URL        string            `json:"url,omitempty"`
-	Method     string            `json:"method,omitempty"`
-	Headers    map[string]string `json:"headers,omitempty"`
-	Body       []byte            `json:"body,omitempty"`
+	name       string
+	url        string
+	method     string
+	headers    map[string]string
+	body       []byte
 	urlAsRegex regexp.Regexp
+}
+
+// Equal checks if a request is identical to another
+func (r Request) Equal(r2 Request) bool {
+	return reflect.DeepEqual(r.url, r2.url) &&
+		reflect.DeepEqual(r.method, r2.method) &&
+		reflect.DeepEqual(r.headers, r2.headers) &&
+		reflect.DeepEqual(r.body, r2.body) &&
+		reflect.DeepEqual(r.urlAsRegex, r2.urlAsRegex)
+}
+
+// String returns the name associated with the request
+func (r Request) String() string {
+	return r.name
+}
+
+// WithName allows to add a name to a Request so that it can be better identified when debugging.
+// By the default Request gets a sequential name that can be hard to identify if there are many of them.
+// So if clarity is needed we recommend to change the default name.
+func (r Request) WithName(name string) Request {
+	r.name = name
+	return r
 }
 
 // WithURL returns a new request with the URL attribute set to URL
 func (r Request) WithURL(URL string) Request {
-	r.URL = URL
+	r.url = URL
 	r.urlAsRegex = *regexp.MustCompile(URL)
 	return r
 }
 
 // WithMethod returns a new request with the method attribute set to method
 func (r Request) WithMethod(method string) Request {
-	r.Method = method
+	r.method = method
 	return r
 }
 
 // WithHeader returns a new request with the header header set to value
 func (r Request) WithHeader(header string, value string) Request {
-	r.Headers[header] = value
+	r.headers[header] = value
 	return r
 }
 
 // WithJSONHeader returns a new request with the header `Content-Type` set to `application/json`
 func (r Request) WithJSONHeader() Request {
-	r.Headers["Content-Type"] = "application/json"
+	r.headers["Content-Type"] = "application/json"
 	return r
 }
 
@@ -49,20 +72,20 @@ func (r Request) WithJSONHeader() Request {
 // If multiple headers with the same name are defined only the last one is applied.
 func (r Request) WithHeaders(headers map[string]string) Request {
 	for k, v := range headers {
-		r.Headers[k] = v
+		r.headers[k] = v
 	}
 	return r
 }
 
 // WithBody returns a new request with the method body set to body
 func (r Request) WithBody(body []byte) Request {
-	r.Body = body
+	r.body = body
 	return r
 }
 
 // WithStringBody returns a new request with the method body set to body
 func (r Request) WithStringBody(body string) Request {
-	r.Body = []byte(body)
+	r.body = []byte(body)
 	return r
 }
 
@@ -71,22 +94,8 @@ func (r Request) WithStringBody(body string) Request {
 // This method panics if body cannot be converted to JSON
 func (r Request) WithJSONBody(body any) Request {
 	r = r.WithJSONHeader()
-	r.Body = mustMarshalJSON(body)
+	r.body = mustMarshalJSON(body)
 	return r
-}
-
-// Equal checks if a request is identical to another
-func (r Request) Equal(r2 Request) bool {
-	return reflect.DeepEqual(r, r2)
-}
-
-// String returns a human readable representation
-func (r Request) String() string {
-	bytes, err := json.Marshal(r)
-	if err != nil {
-		panic("cannot marshal request")
-	}
-	return string(bytes)
 }
 
 // NewRequest creates a new request designed to be registered to a Registry to get matched against an incoming HTTP request.
@@ -99,12 +108,29 @@ func (r Request) String() string {
 //		WithJSONHeader().
 //		WithBody([]byte("{\"user\": \"John Schmidt\"}"))
 func NewRequest() Request {
+	return newRequestWithName("")
+}
+
+// newRequestWithName creates a new request designed to be registered to a Registry to get matched against an incoming HTTP request.
+// This function allows to set the name while creating the request,
+// this has the advantage of not increasing the counter in the default naming schema.
+//
+// This function is designed to be used in conjunction with other other receivers.
+// For example
+//
+//	newRequestWithName().
+//		WithURL("/users/1").
+//		WithMethod(http.MethodPatch).
+//		WithJSONHeader().
+//		WithBody([]byte("{\"user\": \"John Schmidt\"}"))
+func newRequestWithName(name string) Request {
 	r := Request{
-		URL:        "",
+		name:       name,
+		url:        "",
 		urlAsRegex: *regexp.MustCompile(".+"),
-		Method:     "",
-		Headers:    make(map[string]string),
-		Body:       make([]byte, 0),
+		method:     "",
+		headers:    make(map[string]string),
+		body:       make([]byte, 0),
 	}
 	return r
 }

--- a/response.go
+++ b/response.go
@@ -1,7 +1,6 @@
 package httpregistry
 
 import (
-	"encoding/json"
 	"net/http"
 )
 
@@ -10,121 +9,126 @@ import (
 
 // Information responses
 var (
-	ContinueResponse           = NewResponse().WithStatus(100)
-	SwitchingProtocolsResponse = NewResponse().WithStatus(101)
-	ProcessingResponse         = NewResponse().WithStatus(102)
-	EarlyHintsResponse         = NewResponse().WithStatus(103)
+	ContinueResponse           = newResponseWithName("httpregistry.ContinueResponse").WithStatus(100)
+	SwitchingProtocolsResponse = newResponseWithName("httpregistry.SwitchingProtocolsResponse").WithStatus(101)
+	ProcessingResponse         = newResponseWithName("httpregistry.ProcessingResponse").WithStatus(102)
+	EarlyHintsResponse         = newResponseWithName("httpregistry.EarlyHintsResponse").WithStatus(103)
 )
 
 // Successful responses
 var (
-	OkResponse                          = NewResponse().WithStatus(200)
-	CreatedResponse                     = NewResponse().WithStatus(201)
-	AcceptedResponse                    = NewResponse().WithStatus(202)
-	NonAuthoritativeInformationResponse = NewResponse().WithStatus(203)
-	NoContentResponse                   = NewResponse().WithStatus(204)
-	ResetContentResponse                = NewResponse().WithStatus(205)
-	PartialContentResponse              = NewResponse().WithStatus(206)
-	MultiStatusResponse                 = NewResponse().WithStatus(207)
-	AlreadyReportedResponse             = NewResponse().WithStatus(208)
+	OkResponse                          = newResponseWithName("httpregistry.OkResponse").WithStatus(200)
+	CreatedResponse                     = newResponseWithName("httpregistry.CreatedResponse").WithStatus(201)
+	AcceptedResponse                    = newResponseWithName("httpregistry.AcceptedResponse").WithStatus(202)
+	NonAuthoritativeInformationResponse = newResponseWithName("httpregistry.NonAuthoritativeInformationResponse").WithStatus(203)
+	NoContentResponse                   = newResponseWithName("httpregistry.NoContentResponse").WithStatus(204)
+	ResetContentResponse                = newResponseWithName("httpregistry.ResetContentResponse").WithStatus(205)
+	PartialContentResponse              = newResponseWithName("httpregistry.PartialContentResponse").WithStatus(206)
+	MultiStatusResponse                 = newResponseWithName("httpregistry.MultiStatusResponse").WithStatus(207)
+	AlreadyReportedResponse             = newResponseWithName("httpregistry.AlreadyReportedResponse").WithStatus(208)
 )
 
 // Redirection messages
 var (
-	MultipleChoicesResponse   = NewResponse().WithStatus(300)
-	MovedPermanentlyResponse  = NewResponse().WithStatus(301)
-	FoundResponse             = NewResponse().WithStatus(302)
-	SeeOtherResponse          = NewResponse().WithStatus(303)
-	NotModifiedResponse       = NewResponse().WithStatus(304)
-	TemporaryRedirectResponse = NewResponse().WithStatus(307)
-	PermanentRedirectResponse = NewResponse().WithStatus(308)
+	MultipleChoicesResponse   = newResponseWithName("httpregistry.MultipleChoicesResponse").WithStatus(300)
+	MovedPermanentlyResponse  = newResponseWithName("httpregistry.MovedPermanentlyResponse").WithStatus(301)
+	FoundResponse             = newResponseWithName("httpregistry.FoundResponse").WithStatus(302)
+	SeeOtherResponse          = newResponseWithName("httpregistry.SeeOtherResponse").WithStatus(303)
+	NotModifiedResponse       = newResponseWithName("httpregistry.NotModifiedResponse").WithStatus(304)
+	TemporaryRedirectResponse = newResponseWithName("httpregistry.TemporaryRedirectResponse").WithStatus(307)
+	PermanentRedirectResponse = newResponseWithName("httpregistry.PermanentRedirectResponse").WithStatus(308)
 )
 
 // Client error responses
 var (
-	BadRequestsResponse                 = NewResponse().WithStatus(400)
-	UnauthorizedResponse                = NewResponse().WithStatus(401)
-	PaymentRequiredResponse             = NewResponse().WithStatus(402)
-	ForbiddenResponse                   = NewResponse().WithStatus(403)
-	NotFoundResponse                    = NewResponse().WithStatus(404)
-	MethodNotAllowedResponse            = NewResponse().WithStatus(405)
-	NotAcceptableResponse               = NewResponse().WithStatus(406)
-	ProxyAuthenticationRequiredResponse = NewResponse().WithStatus(407)
-	RequestTimeoutResponse              = NewResponse().WithStatus(408)
-	ConflictResponse                    = NewResponse().WithStatus(409)
-	GoneResponse                        = NewResponse().WithStatus(410)
-	LengthRequiredResponse              = NewResponse().WithStatus(411)
-	PreconditionFailedResponse          = NewResponse().WithStatus(412)
-	PayloadTooLargeResponse             = NewResponse().WithStatus(413)
-	URITooLongResponse                  = NewResponse().WithStatus(414)
-	UnsupportedMediaTypeResponse        = NewResponse().WithStatus(415)
-	RangeNotSatisfiableResponse         = NewResponse().WithStatus(416)
-	ExpectationFailedResponse           = NewResponse().WithStatus(417)
-	IAmATeapotResponse                  = NewResponse().WithStatus(418)
-	MisdirectedRequestResponse          = NewResponse().WithStatus(421)
-	UpgradeRequiredResponse             = NewResponse().WithStatus(426)
-	ReconditionRequiredResponse         = NewResponse().WithStatus(428)
-	RequestHeaderFieldsTooLargeResponse = NewResponse().WithStatus(431)
-	UnavailableForLegalReasonsResponse  = NewResponse().WithStatus(451)
+	BadRequestsResponse                 = newResponseWithName("httpregistry.BadRequestsResponse").WithStatus(400)
+	UnauthorizedResponse                = newResponseWithName("httpregistry.UnauthorizedResponse").WithStatus(401)
+	PaymentRequiredResponse             = newResponseWithName("httpregistry.PaymentRequiredResponse").WithStatus(402)
+	ForbiddenResponse                   = newResponseWithName("httpregistry.ForbiddenResponse").WithStatus(403)
+	NotFoundResponse                    = newResponseWithName("httpregistry.NotFoundResponse").WithStatus(404)
+	MethodNotAllowedResponse            = newResponseWithName("httpregistry.MethodNotAllowedResponse").WithStatus(405)
+	NotAcceptableResponse               = newResponseWithName("httpregistry.NotAcceptableResponse").WithStatus(406)
+	ProxyAuthenticationRequiredResponse = newResponseWithName("httpregistry.ProxyAuthenticationRequiredResponse").WithStatus(407)
+	RequestTimeoutResponse              = newResponseWithName("httpregistry.RequestTimeoutResponse").WithStatus(408)
+	ConflictResponse                    = newResponseWithName("httpregistry.ConflictResponse").WithStatus(409)
+	GoneResponse                        = newResponseWithName("httpregistry.GoneResponse").WithStatus(410)
+	LengthRequiredResponse              = newResponseWithName("httpregistry.LengthRequiredResponse").WithStatus(411)
+	PreconditionFailedResponse          = newResponseWithName("httpregistry.PreconditionFailedResponse").WithStatus(412)
+	PayloadTooLargeResponse             = newResponseWithName("httpregistry.PayloadTooLargeResponse").WithStatus(413)
+	URITooLongResponse                  = newResponseWithName("httpregistry.URITooLongResponse").WithStatus(414)
+	UnsupportedMediaTypeResponse        = newResponseWithName("httpregistry.UnsupportedMediaTypeResponse").WithStatus(415)
+	RangeNotSatisfiableResponse         = newResponseWithName("httpregistry.RangeNotSatisfiableResponse").WithStatus(416)
+	ExpectationFailedResponse           = newResponseWithName("httpregistry.ExpectationFailedResponse").WithStatus(417)
+	IAmATeapotResponse                  = newResponseWithName("httpregistry.IAmATeapotResponse").WithStatus(418)
+	MisdirectedRequestResponse          = newResponseWithName("httpregistry.MisdirectedRequestResponse").WithStatus(421)
+	UpgradeRequiredResponse             = newResponseWithName("httpregistry.UpgradeRequiredResponse").WithStatus(426)
+	ReconditionRequiredResponse         = newResponseWithName("httpregistry.ReconditionRequiredResponse").WithStatus(428)
+	RequestHeaderFieldsTooLargeResponse = newResponseWithName("httpregistry.RequestHeaderFieldsTooLargeResponse").WithStatus(431)
+	UnavailableForLegalReasonsResponse  = newResponseWithName("httpregistry.UnavailableForLegalReasonsResponse").WithStatus(451)
 )
 
 // Server error responses
 var (
-	InternalServerErrorResponse     = NewResponse().WithStatus(500)
-	NotImplementedResponse          = NewResponse().WithStatus(501)
-	BadGatewayResponse              = NewResponse().WithStatus(502)
-	ServiceUnavailableResponse      = NewResponse().WithStatus(503)
-	GatewayTimeoutResponse          = NewResponse().WithStatus(504)
-	HTTPVersionNotSupportedResponse = NewResponse().WithStatus(505)
-	VariantAlsoNegotiatesResponse   = NewResponse().WithStatus(506)
-	NotExtendedResponse             = NewResponse().WithStatus(510)
-	NetworkAuthenticationResponse   = NewResponse().WithStatus(511)
+	InternalServerErrorResponse     = newResponseWithName("httpregistry.InternalServerErrorResponse").WithStatus(500)
+	NotImplementedResponse          = newResponseWithName("httpregistry.NotImplementedResponse").WithStatus(501)
+	BadGatewayResponse              = newResponseWithName("httpregistry.BadGatewayResponse").WithStatus(502)
+	ServiceUnavailableResponse      = newResponseWithName("httpregistry.ServiceUnavailableResponse").WithStatus(503)
+	GatewayTimeoutResponse          = newResponseWithName("httpregistry.GatewayTimeoutResponse").WithStatus(504)
+	HTTPVersionNotSupportedResponse = newResponseWithName("httpregistry.HTTPVersionNotSupportedResponse").WithStatus(505)
+	VariantAlsoNegotiatesResponse   = newResponseWithName("httpregistry.VariantAlsoNegotiatesResponse").WithStatus(506)
+	NotExtendedResponse             = newResponseWithName("httpregistry.NotExtendedResponse").WithStatus(510)
+	NetworkAuthenticationResponse   = newResponseWithName("httpregistry.NetworkAuthenticationResponse").WithStatus(511)
 )
 
 // Response represents a response that we want to return if the registry finds a request that matches the incoming request.
 // If the match happens then we will return a http response that matches the attributes defined in this struct.
 type Response struct {
-	StatusCode int               `json:"status_code"`
-	Body       []byte            `json:"body,omitempty"`
-	Headers    map[string]string `json:"headers,omitempty"`
+	name       string
+	statusCode int
+	body       []byte
+	headers    map[string]string
 }
 
-// createResponse emits the response encoded in Response to w
-func (res Response) createResponse(w http.ResponseWriter, _ *http.Request) {
-	for k, v := range res.Headers {
+// serveResponse emits the response encoded in Response to w
+func (res Response) serveResponse(w http.ResponseWriter, _ *http.Request) {
+	for k, v := range res.headers {
 		w.Header().Add(k, v)
 	}
-	w.WriteHeader(res.StatusCode)
-	_, err := w.Write(res.Body)
+	w.WriteHeader(res.statusCode)
+	_, err := w.Write(res.body)
 	if err != nil {
 		panic("cannot write body of request")
 	}
 }
 
+// WithName allows to add a name to a Response so that it can be better identified when debugging.
+// By the default Response gets a sequential name that can be hard to identify if there are many of them.
+// So if clarity is needed we recommend to change the default name.
+func (res Response) WithName(name string) Response {
+	res.name = name
+	return res
+}
+
 // String marshal Response to string
 func (res Response) String() string {
-	bytes, err := json.Marshal(res)
-	if err != nil {
-		panic("cannot marshal request")
-	}
-	return string(bytes)
+	return res.name
 }
 
 // WithStatus returns a new response with the StatusCode attribute set to statusCode
 func (res Response) WithStatus(statusCode int) Response {
-	res.StatusCode = statusCode
+	res.statusCode = statusCode
 	return res
 }
 
 // WithHeader returns a new response with the header header set to value
 func (res Response) WithHeader(header string, value string) Response {
-	res.Headers[header] = value
+	res.headers[header] = value
 	return res
 }
 
 // WithJSONHeader returns a new Response with the header `Content-Type` set to `application/json`
 func (res Response) WithJSONHeader() Response {
-	res.Headers["Content-Type"] = "application/json"
+	res.headers["Content-Type"] = "application/json"
 	return res
 }
 
@@ -132,14 +136,14 @@ func (res Response) WithJSONHeader() Response {
 // If multiple headers with the same name are defined only the last one is applied.
 func (res Response) WithHeaders(headers map[string]string) Response {
 	for k, v := range headers {
-		res.Headers[k] = v
+		res.headers[k] = v
 	}
 	return res
 }
 
 // WithBody returns a new request with the method body set to body
 func (res Response) WithBody(body []byte) Response {
-	res.Body = body
+	res.body = body
 	return res
 }
 
@@ -148,7 +152,7 @@ func (res Response) WithBody(body []byte) Response {
 // This method panics if body cannot be converted to JSON
 func (res Response) WithJSONBody(body any) Response {
 	res = res.WithJSONHeader()
-	res.Body = mustMarshalJSON(body)
+	res.body = mustMarshalJSON(body)
 	return res
 }
 
@@ -163,10 +167,27 @@ func (res Response) WithJSONBody(body any) Response {
 //
 // The default response is a 200 without any body nor header
 func NewResponse() Response {
+	return newResponseWithName("")
+}
+
+// newResponseWithName creates a new Response with the name already set,
+// this has the advantage of not increasing the counter in the default naming schema.
+//
+// This function is designed to be used in conjunction with other other receivers.
+// For example
+//
+//	newResponseWithName("httpregistry.John response").
+//		WithStatus(http.StatusOK).
+//		WithJSONHeader().
+//		WithBody([]byte("{\"user\": \"John Schmidt\"}"))
+//
+// The default response is a 200 without any body nor header
+func newResponseWithName(name string) Response {
 	r := Response{
-		StatusCode: 200,
-		Body:       make([]byte, 0),
-		Headers:    make(map[string]string),
+		name:       name,
+		statusCode: 200,
+		body:       make([]byte, 0),
+		headers:    make(map[string]string),
 	}
 
 	return r

--- a/response_custom.go
+++ b/response_custom.go
@@ -1,13 +1,8 @@
 package httpregistry
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 )
-
-// this is a bit of hacky thing to have a default name
-var counter = 0
 
 // CustomResponse allows the user to define a custom made response to any request.
 // In particular it allows to define responses that are functions of the request
@@ -26,28 +21,24 @@ var counter = 0
 //		}
 //	}
 type CustomResponse struct {
-	Name string `json:"name,omitempty"`
+	name string
 	f    func(w http.ResponseWriter, r *http.Request)
 }
 
-// String marshal FunctionalResponse to string
+// String marshal CustomResponse to string
 func (res CustomResponse) String() string {
-	bytes, err := json.Marshal(res)
-	if err != nil {
-		panic("cannot marshal request")
-	}
-	return string(bytes)
+	return res.name
 }
 
-// createResponse emits the response encoded in FunctionalResponse to w
-func (res CustomResponse) createResponse(w http.ResponseWriter, r *http.Request) {
+// serveResponse emits the response encoded in FunctionalResponse to w
+func (res CustomResponse) serveResponse(w http.ResponseWriter, r *http.Request) {
 	res.f(w, r)
 }
 
 // WithName allows to add a name to a FunctionalResponse so that it can be better identified when debugging.
 // By the fault FunctionalResponse gets a sequential name that can be hard to identify if there are many of them
 func (res CustomResponse) WithName(name string) CustomResponse {
-	res.Name = name
+	res.name = name
 	return res
 }
 
@@ -69,7 +60,8 @@ func (res CustomResponse) WithName(name string) CustomResponse {
 //		}
 //	}
 func NewCustomResponse(f func(w http.ResponseWriter, r *http.Request)) CustomResponse {
-	res := CustomResponse{Name: fmt.Sprintf("Custom response %d", counter), f: f}
-	counter++
-	return res
+	return CustomResponse{
+		name: "",
+		f:    f,
+	}
 }

--- a/response_custom_test.go
+++ b/response_custom_test.go
@@ -43,7 +43,7 @@ func (s *TestSuite) TestFunctionalResponse() {
 			server := registry.GetServer()
 			defer server.Close()
 
-			request, err := http.NewRequest(tc.request.Method, server.URL+"/"+tc.request.URL, bytes.NewReader(tc.request.Body))
+			request, err := http.NewRequest(tc.request.method, server.URL+"/"+tc.request.url, bytes.NewReader(tc.request.body))
 			s.NoError(err)
 
 			res, err := client.Do(request)

--- a/response_interface.go
+++ b/response_interface.go
@@ -8,8 +8,8 @@ import "net/http"
 //   - httpregistry.Response -> it allows to define (one or more) status code, body and headers
 //   - httpregistry.CustomResponse -> it allows to define the response as a function of (w, r)
 type mockResponse interface {
-	// createResponse emits the response encoded in the struct that implements mockResponse to w
-	createResponse(w http.ResponseWriter, r *http.Request)
+	// serveResponse emits the response encoded in the struct that implements mockResponse to w
+	serveResponse(w http.ResponseWriter, r *http.Request)
 	// String Marshals the mockResponse into string
 	String() string
 }

--- a/testing.go
+++ b/testing.go
@@ -3,14 +3,15 @@ package httpregistry
 import "fmt"
 
 // TestingT is the subset of [testing.T] (see also [testing.TB]) used by the httpregistry package.
-// The reason why this exists is so that we can mock in testa and check if failures happen when we expect.
-// By design testing.TB make it impossible for the end user to implement the interface so this is the only way to do so
+// The reason why this exists is so that we can mock in test and check if failures happen when we expect.
+// See the readme or the tests for an example of how to use this.
+// By design [testing.TB] make it impossible for the end user to implement the interface so this is the only way to do so
 type TestingT interface {
 	Fail()
 	Errorf(format string, args ...any)
 }
 
-// MockTestingT mocks the testing.T interface and it can be used to assert that test that should fail will fail
+// MockTestingT mocks the [testing.T] interface and it can be used to assert that test that should fail will fail
 type MockTestingT struct {
 	HasFailed bool
 	Messages  []string
@@ -25,4 +26,10 @@ func (f *MockTestingT) Fail() {
 func (f *MockTestingT) Errorf(format string, args ...any) {
 	f.Messages = append(f.Messages, fmt.Sprintf(format, args...))
 	f.Fail()
+}
+
+// NewMockTestingT returns a MockTestingT that can be passed as argument of httpregistry.NewRegistry
+// so that is possible to make assertions on the state of the test or on the message that it returns
+func NewMockTestingT() *MockTestingT {
+	return &MockTestingT{}
 }

--- a/utils.go
+++ b/utils.go
@@ -36,3 +36,13 @@ func mustMarshalJSON(v any) []byte {
 	}
 	return b
 }
+
+// defaultName is used create default names for requests and responses
+func defaultName(baseString string) func() string {
+	counter := 1
+	return func() string {
+		stringToReturn := fmt.Sprintf("%s #%d", baseString, counter)
+		counter++
+		return stringToReturn
+	}
+}


### PR DESCRIPTION
- Request and responses now can have a name that helps them been identified when debugging. If no name is passed a default naming scheme is used. Said scheme is scoped by registry so each registry gets its own default numbering
- Made all attributes of response/request private since we do not marshal to JSON anymore so we do not need to expose all the attributes
- Updated readme with examples
- Update tests